### PR TITLE
Added option to hide tooltips on hover share resources/units icons

### DIFF
--- a/hook/lua/options/options.lua
+++ b/hook/lua/options/options.lua
@@ -160,7 +160,17 @@ table.insert(options.ui.items,
         custom  = GetBooleanStates(),
         set     = SetOptions,
     }) 
-    
+table.insert(options.ui.items,
+    {
+        tip     = "Specify whether or not show tooptip when hover share resources/units icons \n \n Game Session only",
+        title   = "SSB Show Tooltip When Hover Icons",
+        key     = 'SSB_Show_Tooltip_On_Hover',
+        type    = 'toggle',
+        default = true,
+        custom  = GetBooleanStates(),
+        set     = SetOptions,
+    })
+
 -- SSB Ping options
 table.insert(options.ui.items,
     {

--- a/modules/score_board.lua
+++ b/modules/score_board.lua
@@ -663,8 +663,11 @@ function CreateArmyLine(armyID, army)
                  Diplomacy.SendUnits(self.armyID, false) -- share selected units
              end         
         end 
-        Tooltip.AddControlTooltip(group.shareUnitsIcon, str.tooltip('share_units'))
-        
+
+        if GameOptions['SSB_Show_Tooltip_On_Hover']  then
+            Tooltip.AddControlTooltip(group.shareUnitsIcon, str.tooltip('share_units'))
+        end
+
         position = position + iconSize + 5
         group.shareEngyIcon = CreateInfoIcon(group, 'eco.engyIncome.dds')
         --group.shareEngyIcon:SetTexture(modTextures..'eco.engyIncome.dds')
@@ -681,8 +684,11 @@ function CreateArmyLine(armyID, army)
                 Diplomacy.SendResource(self.armyID, 0, 50) -- Share 50% energy
             end 
         end 
-        Tooltip.AddControlTooltip(group.shareEngyIcon, str.tooltip('share_engy'))
-        
+
+        if GameOptions['SSB_Show_Tooltip_On_Hover']  then
+            Tooltip.AddControlTooltip(group.shareEngyIcon, str.tooltip('share_engy'))
+        end
+
         -- UI for showing allied players' energy stats
         position = position + iconSize + 3
         group.engyColumn = UIUtil.CreateText(group, '0', fontSize, fontName)
@@ -707,7 +713,10 @@ function CreateArmyLine(armyID, army)
                 Diplomacy.SendResource(self.armyID, 50, 0) -- Share 50% mass
             end
         end
-        Tooltip.AddControlTooltip(group.shareMassIcon, str.tooltip('share_mass'))
+
+        if GameOptions['SSB_Show_Tooltip_On_Hover']  then
+            Tooltip.AddControlTooltip(group.shareMassIcon, str.tooltip('share_mass'))
+        end
 
         -- UI for showing allied players' mass stats
         position = position + iconSize + 2


### PR DESCRIPTION
The problem - when you hover share units/resources icons, they have tooltip which overlap quite informative part of the table (with how much resources your teammates have), so you need to move over buttons to see all other values (see screenshot below).

I guess that everybody who uses SSB for a while knows "how to share resources/units", you can find it noisy (I think you've memorized that information after the first time you seen/used it).

![image](https://user-images.githubusercontent.com/3112183/99192056-c7b93400-2781-11eb-8697-397cc7cf82a4.png)

The PR adds an option (which should be enabled by default, but it seems that by default it has `nul` value in `GameOptions` - is this bug?) in the settings which allows you to disable these tooltips on share mass/energy/units buttons.

Questions:
- as I mentioned above - it seems that the default value is `nil` rather than `true`, I'm not sure how it could be fixed...
- It seems that we can't hide tooltip after `Tooltip.AddControlTooltip` (I didn't find any info about that), so it will be applied after game restart. If you know how it could be fixed - please tell me.
- If that "problem" is only for me and you think that it will be worse to have such option - please feel free to close the PR :)