### PR TITLE
Fixed getting game/replay id from /savereplay cmd argument in the game

### DIFF
--- a/modules/score_manager.lua
+++ b/modules/score_manager.lua
@@ -245,9 +245,12 @@ function GetReplayId()
         log.Trace('GetReplayId()... from cmd /syncreplay ' .. tostring(id) )
 
     elseif HasCommandLineArg("/savereplay") then
+        -- /savereplay format is gpgnet://local_ip:port/replay_id/USERNAME.SCFAreplay
+        -- see https://github.com/FAForever/downlords-faf-client/blob/b819997b2c4964ae6e6801d5d2eecd232bca5688/src/main/java/com/faforever/client/fa/LaunchCommandBuilder.java#L192
         local url = GetCommandLineArg("/savereplay", 1)[1]
-        local lastpos = string.find(url, "/", 20)
-        id = string.sub(url, 20, lastpos-1)
+        local fistpos = string.find(url, "/", 10) + 1
+        local lastpos = string.find(url, "/", fistpos) - 1
+        id = string.sub(url, fistpos, lastpos)
         log.Trace('GetReplayId()... from cmd /savereplay ' .. tostring(id) )
 
     elseif HasCommandLineArg("/replayid") then


### PR DESCRIPTION
It seems that it was broken in https://github.com/FAForever/downlords-faf-client/commit/1ae6c7e936305f0336ecb9c324e9fc0560b843c3#diff-3d47503b30b47f5a259049a2e45e1eb555b502bd1f9cc68c936394a0d8fc6f1fR192