### PR TITLE
Allow switching to observer when cheats is on

### DIFF
--- a/modules/score_board.lua
+++ b/modules/score_board.lua
@@ -504,7 +504,7 @@ function SetupPlayerLines()
     end
   
     -- create observer's controls
-    if sessionReplay then
+    if sessionReplay or (sessionInfo.Options.CheatsEnabled == 'true') then
         local observer = {}
         observer.armyID = 0 -- will be between army lines (+IDs) and team lines (-IDs) 
         observer.type = 'observer'
@@ -824,7 +824,7 @@ function CreateArmyLine(armyID, army)
     LayoutHelpers.SetDimensions(group, boardWidth, lineSize)
     
     -- enable switching view to players' armies or observer 
-    if (isPlayerArmy or isObserver) and sessionReplay then
+    if (isPlayerArmy or isObserver) and sessionReplay or (sessionInfo.Options.CheatsEnabled == 'true') then
         group.bg = Bitmap(group)
         group.bg:SetSolidColor('00000000')
         group.bg.Height:Set(group.faction.Height)


### PR DESCRIPTION
This behavior is already in the original score.lua. This also removes the need to disable this superb mod when developing a mod.
It also provides a speed slider (when cheats is on)